### PR TITLE
fix(typo): replace instanceOf Error with AppError for consistency

### DIFF
--- a/src/functions/movie.ts
+++ b/src/functions/movie.ts
@@ -67,7 +67,7 @@ export const createHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
             201,
         );
     } catch (error: any) {
-        if (error instanceof Error) {
+        if (error instanceof AppError) {
             return ResponseHandler.failureResponse({
                 message: error.message,
             });


### PR DESCRIPTION
I initially thought it was intentional, but after reviewing the code at https://github.com/10deyon/sls-movies-api/blob/551bfd4713389b4f22c48c94623dd3805413f161/src/functions/movie.ts#L70 which throws an AppError, I realized it's better to use AppError directly for consistency.

Technically, there's no problem with using instanceof Error since AppError extends the Error class, but replacing it with AppError makes the check more explicit and consistent across the codebase. CMIIW.